### PR TITLE
BUGFIX: Result type hint leads to wrong function result

### DIFF
--- a/Neos.Utility.Unicode/Classes/Functions.php
+++ b/Neos.Utility.Unicode/Classes/Functions.php
@@ -137,7 +137,7 @@ abstract class Functions
      * @return integer The character position
      * @api
      */
-    public static function strpos(string $haystack, string $needle, int $offset = 0): int
+    public static function strpos(string $haystack, string $needle, int $offset = 0)
     {
         return mb_strpos($haystack, $needle, $offset, 'UTF-8');
     }


### PR DESCRIPTION
The `int` type hint of `strpos(string $haystack, string $needle, int $offset = 0): int` casts a `FALSE` result of `mb_strpos` to `0`, which leads to a wrong result if `$haystack` does not contain `$needle`.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
